### PR TITLE
Fix DDSLoader::CopyPixels() crash on Win7

### DIFF
--- a/src/common/Misc/DDSLoader.cpp
+++ b/src/common/Misc/DDSLoader.cpp
@@ -208,6 +208,7 @@ void DDSLoader::CopyPixels(void *pDest, uint32_t stride, uint32_t bytesWidth, ui
 {
     for (uint32_t y = 0; y < height; y++)
     {
-        ReadFile(m_handle, (char*)pDest + y*stride, bytesWidth, NULL, NULL);
+        DWORD bytesRead;
+        ReadFile(m_handle, (char*)pDest + y*stride, bytesWidth, &bytesRead, NULL);
     }
 }


### PR DESCRIPTION
"lpNumberOfBytesRead -
This parameter can be NULL only when the lpOverlapped parameter is not NULL."
AV writing 0x0 on Win7.