### PR TITLE
Add world space coordinates map to GBuffer and add its image usage as input attachment

### DIFF
--- a/src/VK/GLTF/GltfPbrPass.cpp
+++ b/src/VK/GLTF/GltfPbrPass.cpp
@@ -551,6 +551,19 @@ namespace CAULDRON_VK
             att_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
             att_states.push_back(att_state);
         }
+        if (defines.Has("HAS_WORLD_COORD_RT"))
+        {
+            VkPipelineColorBlendAttachmentState att_state = {};
+            att_state.colorWriteMask = 0xf;
+            att_state.blendEnable = VK_FALSE;
+            att_state.alphaBlendOp = VK_BLEND_OP_ADD;
+            att_state.colorBlendOp = VK_BLEND_OP_ADD;
+            att_state.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+            att_state.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+            att_state.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+            att_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+            att_states.push_back(att_state);
+        }
         if (defines.Has("HAS_MOTION_VECTORS_RT"))
         {
             VkPipelineColorBlendAttachmentState att_state = {};

--- a/src/VK/base/GBuffer.cpp
+++ b/src/VK/base/GBuffer.cpp
@@ -289,7 +289,7 @@ namespace CAULDRON_VK
         //
         if (m_GBufferFlags & GBUFFER_FORWARD)
         {
-            m_HDR.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_FORWARD], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT), false, "m_HDR");
+            m_HDR.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_FORWARD], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT), false, "m_HDR");
             m_HDR.CreateSRV(&m_HDRSRV);
         }
 
@@ -297,7 +297,7 @@ namespace CAULDRON_VK
         //
         if (m_GBufferFlags & GBUFFER_MOTION_VECTORS)
         {
-            m_MotionVectors.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_MOTION_VECTORS], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT), false, "m_MotionVector");
+            m_MotionVectors.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_MOTION_VECTORS], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT), false, "m_MotionVector");
             m_MotionVectors.CreateSRV(&m_MotionVectorsSRV);
         }
 
@@ -305,7 +305,7 @@ namespace CAULDRON_VK
         //
         if (m_GBufferFlags & GBUFFER_NORMAL_BUFFER)
         {
-            m_NormalBuffer.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_NORMAL_BUFFER], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT), false, "m_NormalBuffer");
+            m_NormalBuffer.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_NORMAL_BUFFER], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT), false, "m_NormalBuffer");
             m_NormalBuffer.CreateSRV(&m_NormalBufferSRV);
         }
 
@@ -313,7 +313,7 @@ namespace CAULDRON_VK
         //
         if (m_GBufferFlags & GBUFFER_WORLD_COORD)
         {
-            m_WorldCoord.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_WORLD_COORD], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT), false, "m_WorldCoord");
+            m_WorldCoord.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_WORLD_COORD], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT), false, "m_WorldCoord");
             m_WorldCoord.CreateSRV(&m_WorldCoordSRV);
         }
 
@@ -321,7 +321,7 @@ namespace CAULDRON_VK
         //
         if (m_GBufferFlags & GBUFFER_DIFFUSE)
         {
-            m_Diffuse.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_DIFFUSE], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT), false, "m_Diffuse");
+            m_Diffuse.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_DIFFUSE], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT), false, "m_Diffuse");
             m_Diffuse.CreateSRV(&m_DiffuseSRV);
         }
 
@@ -329,7 +329,7 @@ namespace CAULDRON_VK
         //
         if (m_GBufferFlags & GBUFFER_SPECULAR_ROUGHNESS)
         {
-            m_SpecularRoughness.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_SPECULAR_ROUGHNESS], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT), false, "m_SpecularRoughness");
+            m_SpecularRoughness.InitRenderTarget(m_pDevice, Width, Height, m_formats[GBUFFER_SPECULAR_ROUGHNESS], m_sampleCount, (VkImageUsageFlags)(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT), false, "m_SpecularRoughness");
             m_SpecularRoughness.CreateSRV(&m_SpecularRoughnessSRV);
         }
 

--- a/src/VK/base/GBuffer.h
+++ b/src/VK/base/GBuffer.h
@@ -16,7 +16,8 @@ namespace CAULDRON_VK
         GBUFFER_MOTION_VECTORS = 4,
         GBUFFER_NORMAL_BUFFER = 8,
         GBUFFER_DIFFUSE = 16,
-        GBUFFER_SPECULAR_ROUGHNESS = 32
+        GBUFFER_SPECULAR_ROUGHNESS = 32,
+        GBUFFER_WORLD_COORD = 64
     } GBufferFlagBits;
 
     typedef uint32_t GBufferFlags;
@@ -81,6 +82,10 @@ namespace CAULDRON_VK
         // normal buffer
         Texture                         m_NormalBuffer;
         VkImageView                     m_NormalBufferSRV;
+
+        // world space coordinates
+        Texture                         m_WorldCoord;
+        VkImageView                     m_WorldCoordSRV;
 
         // HDR
         Texture                         m_HDR;

--- a/src/VK/base/Texture.cpp
+++ b/src/VK/base/Texture.cpp
@@ -272,7 +272,7 @@ namespace CAULDRON_VK
         image_info.queueFamilyIndexCount = 0;
         image_info.pQueueFamilyIndices = NULL;
         image_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-        image_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT; //TODO    
+        image_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT; //TODO    
         image_info.flags = 0;
         image_info.tiling = VK_IMAGE_TILING_OPTIMAL;   // VK_IMAGE_TILING_LINEAR should never be used and will never be faster
 

--- a/src/VK/shaders/GLTFPbrPass-frag.glsl
+++ b/src/VK/shaders/GLTFPbrPass-frag.glsl
@@ -74,6 +74,10 @@ layout(location = HAS_MOTION_VECTORS_RT) out vec2 Output_motionVect;
     layout (location = HAS_NORMALS_RT) out vec4 Output_normal;
 #endif
 
+#ifdef HAS_WORLD_COORD_RT
+    layout (location = HAS_WORLD_COORD_RT) out vec4 Output_worldCoord;
+#endif
+
 //--------------------------------------------------------------------------------------
 //
 // Constant Buffers 
@@ -139,6 +143,10 @@ void main()
 
 #ifdef HAS_DIFFUSE_RT
     Output_diffuseColor = vec4(diffuseColor, 0);
+#endif
+
+#ifdef HAS_WORLD_COORD_RT
+    Output_worldCoord = vec4(Input.WorldPos, 1);
 #endif
 
 #ifdef HAS_NORMALS_RT


### PR DESCRIPTION
An additional G-Buffer, world space coordinates, is added to GBuffer class. This will benefit in calculating screen-space method such as SSAO and RSM. Also, all the geometry data in GBuffer class are modified to support usage as input attachment for directly loading pixel from subpass to subpass.